### PR TITLE
Density surface options

### DIFF
--- a/inst/shiny-examples/eradication_app/R/maps_code.R
+++ b/inst/shiny-examples/eradication_app/R/maps_code.R
@@ -94,9 +94,8 @@ make_dens_surface<- function(rr, mod, modname, form, buff) {
 	#back transform from link scale.
 	if(modname %in% "occMS"){preds<-plogis(preds.lin)} else
 	{preds<-exp(preds.lin)}
-	preds_rs<- calc_min_max(preds)
 	predras<- rast(rr)
-	predras[]<-preds_rs
+	predras[]<-preds
 	predras
 }
 
@@ -107,7 +106,7 @@ make_resid_dens_surface<- function(rr, mod, locs, buff) {
 	tr<- traject(mod)
 	tr<- tibble(ID=seq_len(nrow(locs)), R = as.vector(tr[,ncol(tr)]))
 	habvals<- left_join(habvals, tr, by = "ID")
-	predras<- rast(rr)
+	predras<- rr
 	predras[habvals$cell]<- habvals$R
 	predras
 }

--- a/inst/shiny-examples/eradication_app/R/utils.R
+++ b/inst/shiny-examples/eradication_app/R/utils.R
@@ -27,11 +27,10 @@ make_summary<- function(mod, mod_type){
 		state<- sum_model(mod_summ, 1)
 		detect<- sum_model(mod_summ, 2)
 		out<- rbind(state, detect)
-	} else if(mod_type %in% "remMNO"){
+	} else if(mod_type %in% "remMNS"){
 		state<- sum_model(mod_summ, 1)
-		growth<- sum_model(mod_summ, 2)
-		detect<- sum_model(mod_summ, 3)
-		out<- rbind(state,growth,detect)
+		detect<- sum_model(mod_summ, 2)
+		out<- rbind(state,detect)
 	} else if(mod_type %in% "occMS") {
 		state<- sum_model(mod_summ, 1)
 		growth<- sum_model(mod_summ, 2)
@@ -74,9 +73,9 @@ make_abund<- function(mod, mod_type){
 			resid<- data.frame(Parameter = "Residual", Session=2, Nhat$Nresid)
 			out<- rbind(total, resid)
 			row.names(out)<- NULL
-		} else if(mod_type %in% "remMNO") {
+		} else if(mod_type %in% "remMNS") {
 			Nhat<- calcN(mod)
-			tmp<- Nhat$Nseason
+			tmp<- Nhat$Nhat
 			seas<- tmp[['.season']]
 			tmp[['.season']]<- NULL
 			total<- data.frame(Parameter = "Total", Session=seas, tmp)

--- a/inst/shiny-examples/eradication_app/server.R
+++ b/inst/shiny-examples/eradication_app/server.R
@@ -292,7 +292,6 @@ DensRast<-reactive({
 	bound<- site_bound()
 	#get the names of the coefficients that are actually in the model:
 	form<- state_formula()
-
 	predras<- make_dens_surface(rast, mod, modname, form, buff)
 	predras<- terra::mask(predras, vect(bound))
 	predras
@@ -372,7 +371,7 @@ observeEvent(input$EstDens, {
 	req(input$Run_model)
 	bound<-site_bound()
 	modname<-ModToFit()
-	if(modname %in% "occMS"){leglab<-"Pr(Occ) for pest"} else {leglab<-"Pest density"}
+	if(modname %in% "occMS"){leglab<-"Pr(Occ) for pest"} else {leglab<-"Relative density"}
 	DensRast <- DensRast()
 	opacity<-habopacity()
 	transparency<-1-opacity

--- a/inst/shiny-examples/eradication_app/server.R
+++ b/inst/shiny-examples/eradication_app/server.R
@@ -142,6 +142,9 @@ state_formula<-reactive({
 	as.formula(form)
 })
 
+DensToPlot<- reactive({
+	input$DStype
+})
 
 fit_mod<-reactive({
 	#fit the selected model to the data.
@@ -290,10 +293,17 @@ DensRast<-reactive({
 	buff<- buff()  #buffer zone radius
 	rast<- hab_raster()
 	bound<- site_bound()
+	DTP<- DensToPlot()
+	traps<- traps()
+	traps_sf<- st_as_sf(traps, coords=c(1,2), crs=st_crs(bound))
 	#get the names of the coefficients that are actually in the model:
 	form<- state_formula()
-	predras<- make_dens_surface(rast, mod, modname, form, buff)
+	Irast<- make_dens_surface(rast, mod, modname, form, buff)
+	Rrast<- make_resid_dens_surface(Irast, mod, traps_sf, buff)
+	if(DTP %in% "IDens") predras<- Irast
+	else predras<- Rrast
 	predras<- terra::mask(predras, vect(bound))
+	predras<- app(predras, calc_min_max)
 	predras
 })
 

--- a/inst/shiny-examples/eradication_app/server.R
+++ b/inst/shiny-examples/eradication_app/server.R
@@ -78,7 +78,7 @@ observeEvent(input$EstDens, {
 	updateTabsetPanel(session, "maintabs",
 										selected = "panel1")
 })
-observe(if(input$Model %in% c("remGRM","remMNO")) {
+observe(if(input$Model %in% c("remGRM","remMNS")) {
 	updateNumericInput(session, "K", value=5*max(removals()) + 50) #sets default value for K on model select
 })
 
@@ -86,7 +86,7 @@ observe(if(input$Model %in% c("remGP")) {
 	updateNumericInput(session, "K", value=5*max(cedata()$catch) + 50) #sets default value for K on model select
 })
 
-observe(if(input$Model %in% c("occMS","remMNO")) {
+observe(if(input$Model %in% c("occMS","remMNS")) {
 	if(!is.null(removals()$session))
 		updateNumericInput(session, "pperiods", value=unstack.data(removals())$T) #update primary periods
 	else
@@ -135,10 +135,13 @@ EstDens<-reactive({
 	})
 
 state_formula<-reactive({
+	modname<- ModToFit()
 	modelvars<-input$state_formula
 	if(length(modelvars)==0) {form="1"} else
 	{form=paste0(modelvars, collapse="+") }
 	form<-paste0("~",form)
+	if(modname %in% "remMNS")
+		form<- paste0(form,"+ .season")
 	as.formula(form)
 })
 
@@ -177,10 +180,8 @@ if(modname== "remGRM"  ) {emf<- eFrameGRM(y=removals,     #removal data
 		                     							 mdetformula=~1,
 		                     							 data=emf,
 		                     							 K=K)} else
-if(modname== "remMNO" )  {emf=eFrameMNO(df=removals, siteCovs = site.data)
-	                        model=remMNO(lamformula=state_formula(), gamformula=~1,
-	                        						 omformula=~1, detformula = ~1, dynamics="trend",
-	                        						 data=emf, K=K)} else
+if(modname== "remMNS" )  {emf=eFrameMNS(df=removals, siteCovs = site.data)
+	                        model=remMNS(lamformula=state_formula(), detformula = ~1, data=emf)} else
 if(modname=="occMS")   {emf=eFrameMS(df=removals, siteCovs=site.data)
                          model=occMS(lamformula = state_formula(), gamformula = ~1,
                          						 epsformula= ~1,detformula= ~1, data=emf)}
@@ -205,7 +206,7 @@ removal_plot<-reactive({
 		effort<- rep(nrow(removals), length(catch))
 		plot_data<- tibble(catch=catch, effort=effort, session=1)
 		plot_data<- plot_data %>% mutate(cpue = catch/effort, ccatch = cumsum(catch))
-	} else if(mod_type %in% c("remMNO","occMS")){
+	} else if(mod_type %in% c("remMNS","occMS")){
 		removals<- removals()
 		tmp<- removals %>% pivot_longer(!session, names_to="period", values_to="catch")
 		plot_data<- tmp %>% group_by(session,period) %>% summarise(catch=sum(catch), .groups="keep")
@@ -294,12 +295,13 @@ DensRast<-reactive({
 	rast<- hab_raster()
 	bound<- site_bound()
 	DTP<- DensToPlot()
+	removals<- removals()
 	traps<- traps()
 	traps_sf<- st_as_sf(traps, coords=c(1,2), crs=st_crs(bound))
 	#get the names of the coefficients that are actually in the model:
 	form<- state_formula()
 	Irast<- make_dens_surface(rast, mod, modname, form, buff)
-	Rrast<- make_resid_dens_surface(Irast, mod, traps_sf, buff)
+	Rrast<- make_resid_dens_surface(Irast, mod, modname, removals, traps_sf, buff)
 	if(DTP %in% "IDens") predras<- Irast
 	else predras<- Rrast
 	predras<- terra::mask(predras, vect(bound))

--- a/inst/shiny-examples/eradication_app/ui.R
+++ b/inst/shiny-examples/eradication_app/ui.R
@@ -5,14 +5,13 @@ require(shinycssloaders)
 require(shinyBS)
 require(waiter)
 require(sf)
-#require(raster)
 require(terra)
 require(tidyverse)
 require(R.utils)
 require(eradicate)
 require(leaflet)
-require(rgdal)
-require(rgeos)
+#require(rgdal)
+#require(rgeos)
 require(xtable)
 require(markdown)
 ##DEFINE THE USER INTERFACE################################################################################################
@@ -37,7 +36,7 @@ ui<-fluidPage(
 		 				 						 choices=list("Nonspatial removals (single or multi-season)"="remGP",
 		 				 						 						 "Spatial removal data (single season)"="remMN",
 		 				 						 						 "Spatial removal data with auxilary detections (single season)"="remGRM",
-		 				 						 						 "Spatial removal data (multi-season)"="remMNO",
+		 				 						 						 "Spatial removal data (multi-season)"="remMNS",
 		 				 						 						 "Spatial presence/absence data (multiseason)"="occMS"
 		 				 						 ), selected="remGP"), "remGP-aspatial removal data<br>remMN-spatially referenced removal data<br>remGRM-spatially referenced removal data with auxilary detections")
 		 				 ),
@@ -65,7 +64,7 @@ ui<-fluidPage(
 		 								 fileInput(inputId="detections", label="Detection histories (.csv)", accept=c("text/csv", ".csv")))),br(), #end conditional block
 		 fluidRow(
 		 	column(3,
-		 conditionalPanel("input.Model=='remMNO' | input.Model=='occMS'",
+		 conditionalPanel("input.Model=='remMNS' | input.Model=='occMS'",
 		 numericInput(inputId="pperiods", "Sessions", min=0, max=NA, value=1, step=1))))
 		 ),
 		 hr(),

--- a/inst/shiny-examples/eradication_app/ui.R
+++ b/inst/shiny-examples/eradication_app/ui.R
@@ -81,7 +81,7 @@ ui<-fluidPage(
 		 hr(),
 		 #SELECT APPROPRIATE MODEL --------------------------------------------------------------------------
 		 fluidRow(
-		 	column(6,conditionalPanel("input.Model!='remGP'",
+		 	column(5,conditionalPanel("input.Model!='remGP'",
 		 				 tipify(checkboxGroupInput(inputId="state_formula", label="habitat covariates",
 		 				 													choices=NULL,
 		 				 													selected=NULL
@@ -89,8 +89,10 @@ ui<-fluidPage(
 		 			 			               If none selected an intercept-only model will be fitted"))
 
 		 	),
-		 	column(3, actionButton(inputId="Run_model", label="Fit model", class = "btn-success"),br(),
+		 	column(5, actionButton(inputId="Run_model", label="Fit model", class = "btn-success"),br(),
 		 				 actionButton(inputId="EstDens", "Estimate Density Surface"),br(),
+		 				 radioButtons(inputId = "DStype", label = "", choices = list("Initial" = "IDens",
+		 				 																																				"Residual" = "RDens"), selected = "IDens", inline=TRUE),br(),
 		 				 downloadButton("download","Download Density Raster")) ,width=7, fluid=TRUE)),
 mainPanel(
 tabsetPanel(id="maintabs", type="tabs",


### PR DESCRIPTION
##This PR should be reviewed before merging.##  

 I have used a different open population model, the 'stacked' model which models changes between primary periods (pp) as a simple fixed effect of .season (categorical) or .trend (numeric).  This model gives population abundance for each pp but does not explicitly model the additions and/or losses.   I think this model will be more robust but this still needs testing.  Try it out with the Wilson's Prom data.

I have also included an option for the density surface plots to plot the 'residual' density along with the 'initial' density.  The residual density is only calculated in the vicinity of the trap locations with radius buff().  For open models, the  abundance for each trap is calculated for the final pp using empirical bayes and then the removals in the final pp subtracted.   The cells in the initial abundance raster corresponding to each buffered trap are then updated with the residual abundance values.

Finally, the absolute abundances are re-scaled on the unit interval. This is so people are not tempted to intepret a cell value as an actual abundance as cell resolution of the habitat raster could be arbitrary.